### PR TITLE
feat: complete Phase 1 Core Mutations (v1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Working with deeply nested JSON in Python is painful. Standard `dict` access bre
 | 🔍 **Traverse** | `traverse_json` | Recursively yield every `(path, value)` pair |
 | 📦 **Flatten** | `flatten_json` | Collapse nested JSON into a single-level dict |
 | 🎯 **Get by path** | `get_value_at_path` | Retrieve a value using a dot-notation path |
+| ✍️ **Set by path** | `set_value_at_path` | Update or set a value at a dot-notation path |
+| 🗑️ **Delete by path** | `delete_at_path` | Remove a key/index at a dot-notation path |
+| 🧹 **Delete key** | `delete_key` | Recursively remove every occurrence of a key |
 | 🔎 **Find value** | `find_value_of_element` | Search for first occurrence of a key, anywhere |
 | 🗺️ **Find all paths** | `find_all_paths_for_element` | Get every path where a key exists |
 | 🧹 **Clear values** | `empty_all_the_values` | Reset all leaf values to `""` in-place |
@@ -105,6 +108,8 @@ flat = flatten_json(data)
 ## 📖 Usage Guide
 
 ### 1️⃣ Traverse Nested JSON
+<details>
+<summary>View Details</summary>
 
 Yields `(path, value)` tuples for every leaf node. Supports mixed dicts and lists.
 
@@ -129,9 +134,13 @@ Path: a.c, Value: 3
 > traverse_json(data, separator="/")  # a/b[0], a/b[1], a/c
 > ```
 
+</details>
+
 ---
 
 ### 2️⃣ Get Value at a Specific Path
+<details>
+<summary>View Details</summary>
 
 ```python
 from jsoninja import get_value_at_path
@@ -142,9 +151,49 @@ print(get_value_at_path(data, "a.b[2]"))   # 30
 print(get_value_at_path(data, "a.b[0]"))   # 10
 ```
 
+</details>
+
 ---
 
-### 3️⃣ Flatten JSON
+### 3️⃣ Set Value at a Specific Path
+<details>
+<summary>View Details</summary>
+
+Update or create a leaf value using dot notation, modifying the dict in place.
+
+```python
+from jsoninja import set_value_at_path
+
+data = {"user": {"scores": [10, 20]}}
+set_value_at_path(data, "user.scores[1]", 99)
+print(data)  # {"user": {"scores": [10, 99]}}
+```
+
+</details>
+
+---
+
+### 4️⃣ Delete Value at a Specific Path
+<details>
+<summary>View Details</summary>
+
+Delete a key or pop an index at the specified path.
+
+```python
+from jsoninja import delete_at_path
+
+data = {"a": {"b": 1, "c": 2}}
+delete_at_path(data, "a.b")
+print(data)  # {"a": {"c": 2}}
+```
+
+</details>
+
+---
+
+### 5️⃣ Flatten JSON
+<details>
+<summary>View Details</summary>
 
 Collapses any depth of nesting into a flat `{path: value}` dictionary.
 
@@ -163,9 +212,13 @@ print(flatten_json(data))
 }
 ```
 
+</details>
+
 ---
 
-### 4️⃣ Find a Value by Key
+### 6️⃣ Find a Value by Key
+<details>
+<summary>View Details</summary>
 
 Returns the first occurrence of a key anywhere in the structure.
 
@@ -177,9 +230,13 @@ print(find_value_of_element("c", data))  # 42
 print(find_value_of_element("z", data))  # "" (not found)
 ```
 
+</details>
+
 ---
 
-### 5️⃣ Find All Paths for a Key
+### 7️⃣ Find All Paths for a Key
+<details>
+<summary>View Details</summary>
 
 Returns **every** path where the target key appears — great for duplicate-key analysis.
 
@@ -191,9 +248,13 @@ print(find_all_paths_for_element(data, "a"))
 # ["a", "b.a", "c[0].a"]
 ```
 
+</details>
+
 ---
 
-### 6️⃣ Empty All Values
+### 8️⃣ Empty All Values
+<details>
+<summary>View Details</summary>
 
 Resets every leaf value to `""` — useful for creating JSON templates or anonymising data.
 
@@ -214,9 +275,31 @@ print(empty_all_the_values(data))
 }
 ```
 
+</details>
+
 ---
 
-### 7️⃣ Validate & Format Paths
+### 9️⃣ Recursively Delete a Key
+<details>
+<summary>View Details</summary>
+
+Recursively remove every occurrence of a key name anywhere in the nested object.
+
+```python
+from jsoninja import delete_key
+
+data = {"id": 1, "user": {"id": 2, "name": "Alice"}}
+delete_key(data, "id")
+print(data)  # {"user": {"name": "Alice"}}
+```
+
+</details>
+
+---
+
+### 🔟 Validate & Format Paths
+<details>
+<summary>View Details</summary>
 
 ```python
 from jsoninja import validate_path, format_path
@@ -234,9 +317,13 @@ print(format_path("user.address.city"))   # user -> address -> city
 print(format_path("a.b[1]"))             # a -> b[1]
 ```
 
+</details>
+
 ---
 
-### 8️⃣ Compare Two JSON Structures
+### 1️⃣1️⃣ Compare Two JSON Structures
+<details>
+<summary>View Details</summary>
 
 Diff two JSON objects or files and receive a structured list of changes plus a summary.
 
@@ -279,6 +366,8 @@ changes, summary = compare_files(
 | `changed` | Same path, different value |
 | `type_changed` | Same path, different Python type |
 
+</details>
+
 ---
 
 ## 🗂️ Project Structure
@@ -313,6 +402,9 @@ JSONavigator/
 |---|---|---|
 | `traverse_json` | `(data, parent_key='', separator='.')` | Generator of `(path, value)` |
 | `get_value_at_path` | `(data, path, separator='.')` | Value at the path |
+| `set_value_at_path` | `(data, path, new_value, separator='.')` | Mutated `data` |
+| `delete_at_path` | `(data, path, separator='.')` | Mutated `data` |
+| `delete_key` | `(data, target_key)` | Mutated `data` |
 | `find_value_of_element` | `(target_key, data)` | First matched value or `""` |
 | `find_all_paths_for_element` | `(file_data, target_key, path='', separator='.')` | `list[str]` of all paths |
 | `empty_all_the_values` | `(data)` | Mutated `data` with `""` leaves, or `None` |
@@ -425,8 +517,8 @@ Please follow the existing code style and write docstrings for any new functions
 
 ## 🚀 Roadmap
 
-- [ ] `set_value_at_path` — update a value at a given path in place
-- [ ] `delete_key` — remove a key anywhere in the structure
+- [x] `set_value_at_path` — update a value at a given path in place
+- [x] `delete_key` — remove a key anywhere in the structure
 - [ ] JSONPath (`$`) query syntax support
 - [ ] Async-friendly streaming traversal for large JSON files
 - [ ] Type-annotated stubs (`py.typed` marker)

--- a/jsoninja/__init__.py
+++ b/jsoninja/__init__.py
@@ -4,7 +4,10 @@ from jsoninja.core import (
     get_value_at_path,
     find_all_paths_for_element,
     find_value_of_element,
-    empty_all_the_values
+    empty_all_the_values,
+    set_value_at_path,
+    delete_at_path,
+    delete_key
 )
 
 # Import utils functions from the utils module
@@ -47,7 +50,10 @@ __all__ = [
     "validate_path",
     "format_path",
     "flatten_json",
-    "compare_files"
+    "compare_files",
+    "set_value_at_path",
+    "delete_at_path",
+    "delete_key"
 ]
 
 import importlib.metadata

--- a/jsoninja/core.py
+++ b/jsoninja/core.py
@@ -1,5 +1,5 @@
 import re
-from .exceptions import KeyNotFoundError, IndexOutOfRangeError, InvalidDataTypeError
+from .exceptions import KeyNotFoundError, IndexOutOfRangeError, InvalidDataTypeError, InvalidPathError
 
 def traverse_json(data, parent_key='', separator='.'):
     """
@@ -146,3 +146,140 @@ def empty_all_the_values(data):
             else:
                 data[i] = ""
         return data
+
+
+def set_value_at_path(data, path, new_value, separator='.'):
+    """
+    Update a leaf value at a given dot-notation path.
+    :param data: The JSON data (dict or list).
+    :param path: The path to the desired element.
+    :param new_value: The value to set.
+    :param separator: The separator used in the path.
+    :return: The mutated JSON data.
+    """
+    pattern = re.compile(rf'[^{re.escape(separator)}\[\]]+|\[\d+\]')
+    components = pattern.findall(path)
+    
+    if not components:
+        raise InvalidPathError("Path cannot be empty or invalid.")
+        
+    current = data
+    
+    # Traverse to the parent of the target node
+    for component in components[:-1]:
+        if component.startswith('[') and component.endswith(']'):
+            index = int(component[1:-1])
+            if isinstance(current, list):
+                try:
+                    current = current[index]
+                except IndexError:
+                    raise IndexOutOfRangeError(index)
+            else:
+                raise InvalidDataTypeError(type(current).__name__, f"Index {index} accessed on non-list.")
+        else:
+            if isinstance(current, dict):
+                try:
+                    current = current[component]
+                except KeyError:
+                    raise KeyNotFoundError(component)
+            else:
+                raise InvalidDataTypeError(type(current).__name__, f"Key {component} accessed on non-dictionary.")
+                
+    # Modify the target node
+    last_component = components[-1]
+    if last_component.startswith('[') and last_component.endswith(']'):
+        index = int(last_component[1:-1])
+        if isinstance(current, list):
+            try:
+                current[index] = new_value
+            except IndexError:
+                raise IndexOutOfRangeError(index)
+        else:
+            raise InvalidDataTypeError(type(current).__name__, f"Index {index} accessed on non-list.")
+    else:
+        if isinstance(current, dict):
+            current[last_component] = new_value
+        else:
+            raise InvalidDataTypeError(type(current).__name__, f"Key {last_component} accessed on non-dictionary.")
+            
+    return data
+
+
+def delete_at_path(data, path, separator='.'):
+    """
+    Remove the key/index at the given path from the structure.
+    :param data: The JSON data (dict or list).
+    :param path: The path to the element to delete.
+    :param separator: The separator used in the path.
+    :return: The mutated JSON data.
+    """
+    pattern = re.compile(rf'[^{re.escape(separator)}\[\]]+|\[\d+\]')
+    components = pattern.findall(path)
+    
+    if not components:
+        raise InvalidPathError("Path cannot be empty or invalid.")
+        
+    current = data
+    
+    # Traverse to the parent of the target node
+    for component in components[:-1]:
+        if component.startswith('[') and component.endswith(']'):
+            index = int(component[1:-1])
+            if isinstance(current, list):
+                try:
+                    current = current[index]
+                except IndexError:
+                    raise IndexOutOfRangeError(index)
+            else:
+                raise InvalidDataTypeError(type(current).__name__, f"Index {index} accessed on non-list.")
+        else:
+            if isinstance(current, dict):
+                try:
+                    current = current[component]
+                except KeyError:
+                    raise KeyNotFoundError(component)
+            else:
+                raise InvalidDataTypeError(type(current).__name__, f"Key {component} accessed on non-dictionary.")
+                
+    # Delete the target node
+    last_component = components[-1]
+    if last_component.startswith('[') and last_component.endswith(']'):
+        index = int(last_component[1:-1])
+        if isinstance(current, list):
+            try:
+                current.pop(index)
+            except IndexError:
+                raise IndexOutOfRangeError(index)
+        else:
+            raise InvalidDataTypeError(type(current).__name__, f"Index {index} accessed on non-list.")
+    else:
+        if isinstance(current, dict):
+            try:
+                del current[last_component]
+            except KeyError:
+                raise KeyNotFoundError(last_component)
+        else:
+            raise InvalidDataTypeError(type(current).__name__, f"Key {last_component} accessed on non-dictionary.")
+            
+    return data
+
+
+def delete_key(data, target_key):
+    """
+    Recursively remove every occurrence of a key name anywhere in the structure.
+    :param data: The JSON data (dict or list).
+    :param target_key: The target key to remove.
+    :return: The mutated JSON data.
+    """
+    if isinstance(data, dict):
+        if target_key in data:
+            del data[target_key]
+        for key, value in list(data.items()):
+            if isinstance(value, (dict, list)):
+                delete_key(value, target_key)
+    elif isinstance(data, list):
+        for item in data:
+            if isinstance(item, (dict, list)):
+                delete_key(item, target_key)
+                
+    return data

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="jsonavigator",
-    version="1.1.0",
+    version="1.2.0",
     author="Nikhil Singh",
     author_email="nikhilraj7654@gmail.com",
     description="A Python package for handling nested JSON structures.",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 import pytest
 from jsoninja.core import *
-from jsoninja.exceptions import InvalidDataTypeError, KeyNotFoundError, IndexOutOfRangeError
+from jsoninja.exceptions import InvalidDataTypeError, KeyNotFoundError, IndexOutOfRangeError, InvalidPathError
 
 def test_traverse_json():
     data = {"a": {"b": [1, 2], "c": 3}}
@@ -271,3 +271,91 @@ def test_find_value_falsy_matches():
     assert find_value_of_element("b", data) == 0
     assert find_value_of_element("c", data) is False
     assert find_value_of_element("d", data) == ""
+
+
+# --- Tests for set_value_at_path ---
+
+def test_set_value_at_path_dict():
+    data = {"a": {"b": 1, "c": 2}}
+    assert set_value_at_path(data, "a.b", 99) == {"a": {"b": 99, "c": 2}}
+    assert data["a"]["b"] == 99  # mutates in place
+
+def test_set_value_at_path_list():
+    data = {"user": {"scores": [10, 20]}}
+    assert set_value_at_path(data, "user.scores[1]", 99) == {"user": {"scores": [10, 99]}}
+
+def test_set_value_at_path_new_key():
+    data = {"a": {"b": 1}}
+    assert set_value_at_path(data, "a.c", 2) == {"a": {"b": 1, "c": 2}}
+
+def test_set_value_at_path_exceptions():
+    data = {"a": {"b": [1, 2]}}
+    # Invalid path
+    with pytest.raises(InvalidPathError):
+        set_value_at_path(data, "", 99)
+    # Missing parent key
+    with pytest.raises(KeyNotFoundError):
+        set_value_at_path(data, "x.y", 99)
+    # Index out of range
+    with pytest.raises(IndexOutOfRangeError):
+        set_value_at_path(data, "a.b[5]", 99)
+    # Bad access type
+    with pytest.raises(InvalidDataTypeError):
+        set_value_at_path(data, "a.b.c", 99)
+
+
+# --- Tests for delete_at_path ---
+
+def test_delete_at_path_dict():
+    data = {"a": {"b": 1, "c": 2}}
+    assert delete_at_path(data, "a.b") == {"a": {"c": 2}}
+
+def test_delete_at_path_list():
+    data = {"a": [10, 20, 30]}
+    assert delete_at_path(data, "a[1]") == {"a": [10, 30]}
+
+def test_delete_at_path_exceptions():
+    data = {"a": {"b": [1, 2]}}
+    # Invalid path
+    with pytest.raises(InvalidPathError):
+        delete_at_path(data, "")
+    # Missing parent key
+    with pytest.raises(KeyNotFoundError):
+        delete_at_path(data, "x.y")
+    # Missing target key
+    with pytest.raises(KeyNotFoundError):
+        delete_at_path(data, "a.c")
+    # Index out of range
+    with pytest.raises(IndexOutOfRangeError):
+        delete_at_path(data, "a.b[5]")
+
+
+# --- Tests for delete_key ---
+
+def test_delete_key_flat():
+    data = {"id": 1, "name": "Alice"}
+    assert delete_key(data, "id") == {"name": "Alice"}
+
+def test_delete_key_nested():
+    data = {"id": 1, "user": {"id": 2, "name": "Alice"}}
+    assert delete_key(data, "id") == {"user": {"name": "Alice"}}
+
+def test_delete_key_list():
+    data = [{"id": 1, "val": "a"}, {"id": 2, "val": "b"}]
+    assert delete_key(data, "id") == [{"val": "a"}, {"val": "b"}]
+
+def test_delete_key_mixed():
+    data = {
+        "id": 1,
+        "items": [
+            {"id": 2, "name": "item1"},
+            {"id": 3, "name": "item2", "details": {"id": 4, "desc": "none"}}
+        ]
+    }
+    expected = {
+        "items": [
+            {"name": "item1"},
+            {"name": "item2", "details": {"desc": "none"}}
+        ]
+    }
+    assert delete_key(data, "id") == expected


### PR DESCRIPTION
feat: implement Phase 1 Core Mutations and bump version to 1.2.0

* Add [set_value_at_path](cci:1://file:///Users/nikhilkumar/Documents/Projects/JSONavigator/jsoninja/core.py:150:0-204:15) to update or create values using dot-notation paths
* Add [delete_at_path](cci:1://file:///Users/nikhilkumar/Documents/Projects/JSONavigator/jsoninja/core.py:207:0-263:15) to remove keys/indices using dot-notation paths
* Add [delete_key](cci:1://file:///Users/nikhilkumar/Documents/Projects/JSONavigator/jsoninja/core.py:266:0-284:15) to recursively remove all occurrences of a target key
* Expose new core functions in the public API ([jsoninja/__init__.py](cci:7://file:///Users/nikhilkumar/Documents/Projects/JSONavigator/jsoninja/__init__.py:0:0-0:0))
* Add comprehensive pytest suite for new functions in [tests/test_core.py](cci:7://file:///Users/nikhilkumar/Documents/Projects/JSONavigator/tests/test_core.py:0:0-0:0)
* Update [README.md](cci:7://file:///Users/nikhilkumar/Documents/Projects/JSONavigator/README.md:0:0-0:0) with new features, collapsible code examples in the Usage Guide, and updated Roadmap
* Bump package version to 1.2.0 in `setup.py`
